### PR TITLE
fix: outdent indented numbered-list items (2 tutorials)

### DIFF
--- a/tutorials/btp-sdm-gwi-onbrepo-jwt-token/btp-sdm-gwi-onbrepo-jwt-token.md
+++ b/tutorials/btp-sdm-gwi-onbrepo-jwt-token/btp-sdm-gwi-onbrepo-jwt-token.md
@@ -54,7 +54,7 @@ Navigate to the service that you created in the previous tutorial [Create a Serv
 
         !![Select Post](Select Post Method.png)
 
-      4. For encoding, you need to select all the values in the **authorities** field, right click and select the option **EncodeURIComponent**.
+    4. For encoding, you need to select all the values in the **authorities** field, right click and select the option **EncodeURIComponent**.
 
         !![Encoding_Authorities](Encoding_Authorities.png)
 

--- a/tutorials/luigi-app-react/luigi-app-react.md
+++ b/tutorials/luigi-app-react/luigi-app-react.md
@@ -353,7 +353,7 @@ In this step, you will make changes to the entry point `index.js` for the React 
     root.render(<App />);
     ```
 
-  2. Next, go to the `react-core-mf/src/views` directory created in step 6 of the [previous tutorial](luigi-app-basic-setup). Find the file called `home.js` and paste the following code into it:
+2. Next, go to the `react-core-mf/src/views` directory created in step 6 of the [previous tutorial](luigi-app-basic-setup). Find the file called `home.js` and paste the following code into it:
 
     ```JavaScript
     import React, { useState, useEffect } from 'react';


### PR DESCRIPTION
## Summary

Outdents 2 numbered-list items so they sit flush with their sibling markers instead of being interpreted by CommonMark as nested `<ol start="N">` items. Detected by [`tutorials-ims/scripts/lint-tutorial-markdown.ts`](https://github.com/sap-tutorials/tutorials-ims/blob/main/scripts/lint-tutorial-markdown.ts) and tracked in [tutorials-ims#193](https://github.com/sap-tutorials/tutorials-ims/issues/193).

## Changes (2 tutorials)

| Tutorial | Lines | Fix |
|---|---|---|
| `btp-sdm-gwi-onbrepo-jwt-token` | L57 | Outdent `4.` from column 6 to column 4 to match siblings `1.`/`2.`/`3.` (this is a nested list — child of the outer `2.`, NOT flush-left) |
| `luigi-app-react` | L356 | Outdent `2.` from 2-space indent to flush-left to match sibling `1.` |

Per-edit verification: each numbered marker is now flush with its matching sibling. CommonMark continuation content (code blocks, images) within each item retains its existing indent so it remains attached to the right list item.

## Verification

Run [`lint-tutorial-markdown`](https://github.com/sap-tutorials/tutorials-ims/blob/main/scripts/lint-tutorial-markdown.ts) against a fresh `.tutorial-cache/` after merge — these 2 tutorials should drop off the report.

## Related

- Platform-side fix: [tutorials-ims#190](https://github.com/sap-tutorials/tutorials-ims/pull/190) (merged)
- Author-side lint: [tutorials-ims#191](https://github.com/sap-tutorials/tutorials-ims/pull/191) (merged)
- Original report: [tutorials-ims#168](https://github.com/sap-tutorials/tutorials-ims/issues/168) (closed)
- Tracking: [tutorials-ims#193](https://github.com/sap-tutorials/tutorials-ims/issues/193)
