### PR TITLE
Remove products>mobile-development-kit-client tag from generic BAS setup tutorial

### DIFF
--- a/tutorials/appstudio-onboarding/appstudio-onboarding.md
+++ b/tutorials/appstudio-onboarding/appstudio-onboarding.md
@@ -2,7 +2,7 @@
 parser: v2
 auto_validation: true
 time: 10
-tags: [ tutorial>beginner, programming-tool>sapui5, products>sap-fiori, products>sap-business-technology-platform, products>sap-workflow, software-product-function>sap-cloud-application-programming-model, topic>mobile, products>mobile-development-kit-client]
+tags: [ tutorial>beginner, programming-tool>sapui5, products>sap-fiori, products>sap-business-technology-platform, products>sap-workflow, software-product-function>sap-cloud-application-programming-model, topic>mobile]
 primary_tag: products>sap-business-application-studio
 author_name: Raz Korn
 author_profile: https://github.com/raz-korn


### PR DESCRIPTION
Fixes the tagging half of sap-tutorials/tutorials-ims#1639.

## Problem
`tutorials/appstudio-onboarding` ("Set Up SAP Business Application Studio for Development") is a **generic** BAS onboarding tutorial reused as a setup step across many learning paths. Its frontmatter carries `products>mobile-development-kit-client`.

On the tutorial navigator (developers.sap.com), a mission/group's product tags are the **union of its constituent tutorials' tags**. Because this generic setup tutorial is shared by non-MDK missions (e.g. "Get Started with SAP HANA Cloud", "Set Up SAP HANA Cloud"), those missions inherit the MDK tag and wrongly appear when filtering by **Mobile Development Kit Client**.

## Change
Remove `products>mobile-development-kit-client` from the tutorial's `tags`. It is a downstream consumer of BAS setup, not a property of the setup tutorial itself. No other content changes.

```diff
-tags: [ ..., topic>mobile, products>mobile-development-kit-client]
+tags: [ ..., topic>mobile]
```

## Note for the content owner
`topic>mobile` (and arguably `programming-tool>sapui5`, `products>sap-fiori`, `products>sap-workflow`) are similarly broad for a generic BAS setup tutorial and cause comparable cross-pollination on other facets. Left unchanged here to keep the fix scoped to the reported MDK issue — flagging for your consideration.

## After merge
tutorials-ims picks this up on the next content rebuild (`gh workflow run rebuild-content.yml -f slug=appstudio-onboarding`), which refreshes the cached tags and re-derives mission/group facets.